### PR TITLE
Add a configuration key to set/disable buckets' use range

### DIFF
--- a/skyblock_levels/skyblock.feats.lua
+++ b/skyblock_levels/skyblock.feats.lua
@@ -277,12 +277,12 @@ local function bucket_water_on_use(itemstack, user, pointed_thing)
 		-- begin anti-grief change
 		local player_name = user:get_player_name()
 		local spawn = skyblock.get_spawn(player_name)
-		local range = skyblock.start_gap/3 -- how far from spawn you can use water
+		local range = tonumber(minetest.setting_get("bucket_use_range")) or false -- how far from spawn you can use water
 		local pos = pointed_thing.under
-		if spawn==nil 
+		if range and (spawn==nil
 			or (pos.x-spawn.x > range or pos.x-spawn.x < range*-1) 
 			or (pos.y-spawn.y > range/2 or pos.y-spawn.y < range*-1/2) 
-			or (pos.z-spawn.z > range or pos.z-spawn.z < range*-1) then
+			or (pos.z-spawn.z > range or pos.z-spawn.z < range*-1)) then
 			minetest.chat_send_player(player_name, 'Cannot use bucket so far from your home.')
 			return
 		end
@@ -319,9 +319,11 @@ local function bucket_lava_on_use(itemstack, user, pointed_thing)
 		-- begin anti-grief change
 		local player_name = user:get_player_name()
 		local spawn = skyblock.get_spawn(player_name)
-		local range = skyblock.start_gap/3 -- how far from spawn you can use lava
+		local range = tonumber(minetest.setting_get("bucket_use_range")) or false -- how far from spawn you can use lava
 		local pos = pointed_thing.under
-		if spawn==nil or (pos.x-spawn.x > range or pos.x-spawn.x < range*-1) or (pos.z-spawn.z > range or pos.z-spawn.z < range*-1) then
+		if range and (spawn==nil
+			or (pos.x-spawn.x > range or pos.x-spawn.x < range*-1)
+			or (pos.z-spawn.z > range or pos.z-spawn.z < range*-1)) then
 			--if (pos.y-spawn.y > range/2 or pos.y-spawn.y < range*-1/2) then
 				minetest.chat_send_player(player_name, 'Cannot use bucket so far from your home.')
 				return


### PR DESCRIPTION
This is a pull-request intended to solve #49.
It adds a configuration key called `bucket_use_range` read from minetest.conf which determines whether or not buckets' maximum use range is disabled, or what its value is. The default behavior when `bucket_use_range` is not set is to disable maximum bucket use range.
If you want to discuss the way I implemented that feature, please do. (I know there are several other ways I could have done this but this one is the most light/easy I could think of)