### PR TITLE
Fix on_place override (signs are nodes not craftitems)

### DIFF
--- a/skyblock_levels/skyblock.feats.lua
+++ b/skyblock_levels/skyblock.feats.lua
@@ -202,10 +202,10 @@ local function on_place(v, is_craftitem)
 		end
 	end
 end
-for _,v in ipairs({'doors:door_wood','doors:door_glass','doors:door_steel','doors:door_obsidian_glass','default:sign_wall'}) do
+for _,v in ipairs({'doors:door_wood','doors:door_glass','doors:door_steel','doors:door_obsidian_glass'}) do
 	on_place(v,1);
 end
-for _,v in ipairs({'default:cactus', 'farming:seed_wheat', 'farming:seed_cotton'}) do
+for _,v in ipairs({'default:cactus', 'farming:seed_wheat', 'farming:seed_cotton', 'default:sign_wall'}) do
 	on_place(v,0);
 end
 


### PR DESCRIPTION
The fix for signs_lib was good, only one thing was wrong  : whether or not `default:sign_wall` is registered in default or overriden in signs_lib, it's a node, not a craftitem.