### PR TITLE
Check for protection before placing/taking liquid sources

### DIFF
--- a/skyblock_levels/skyblock.feats.lua
+++ b/skyblock_levels/skyblock.feats.lua
@@ -245,8 +245,12 @@ local function bucket_on_use(itemstack, user, pointed_thing)
 	if pointed_thing.type ~= 'node' then
 		return
 	end
+	-- Check if protected
+	if minetest.is_protected(pointed_thing.under, user:get_player_name()) then
+		return
+	end
 	-- Check if pointing to a liquid source
-	local n = minetest.env:get_node(pointed_thing.under)
+	local n = minetest.get_node(pointed_thing.under)
 	local liquid = bucket.liquids[n.name]
 	if liquid ~= nil and liquid.source == n.name and liquid.itemname ~= nil then
 		
@@ -269,8 +273,12 @@ local function bucket_water_on_use(itemstack, user, pointed_thing)
 	if pointed_thing.type ~= 'node' then
 		return
 	end
+	-- Check if protected
+	if minetest.is_protected(pointed_thing.under, user:get_player_name()) then
+		return
+	end
 	-- Check if pointing to a liquid
-	local n = minetest.env:get_node(pointed_thing.under)
+	local n = minetest.get_node(pointed_thing.under)
 	if bucket.liquids[n.name] == nil then
 		-- Not a liquid
 
@@ -311,8 +319,12 @@ local function bucket_lava_on_use(itemstack, user, pointed_thing)
 	if pointed_thing.type ~= 'node' then
 		return
 	end
+	-- Check if protected
+	if minetest.is_protected(pointed_thing.under, user:get_player_name()) then
+		return
+	end
 	-- Check if pointing to a liquid
-	local n = minetest.env:get_node(pointed_thing.under)
+	local n = minetest.get_node(pointed_thing.under)
 	if bucket.liquids[n.name] == nil then
 		-- Not a liquid
 


### PR DESCRIPTION
 - Overriding buckets prevent protector from working correctly, so the check needs to be added when overriding. (I also updated pieces of code around those lines)

(see https://github.com/MinetestForFun/server-minetestforfun-skyblock/issues/25 and https://github.com/MinetestForFun/server-minetestforfun-skyblock/commit/9f87fb7d382441eaca7184ad7b625459ccb1520b)