### PR TITLE
Handle unloaded islands when placing the water source

### DIFF
--- a/skyblock_levels/skyblock.levels.2.lua
+++ b/skyblock_levels/skyblock.levels.2.lua
@@ -163,8 +163,20 @@ skyblock.levels[level].reward_feat = function(player_name, feat)
 	if rewarded and feat == 'dig_stone_with_iron' then
 		local pos = skyblock.get_spawn(player_name)
 		local y_up = 1
-		while minetest.get_node({x=pos.x, y=pos.y+y_up, z=pos.z}).name ~= "air" do
-			y_up = y_up + 1
+		while 1 == 1 do
+			local node = minetest.get_node({x=pos.x, y=pos.y+y_up, z=pos.z}).name
+			if node ~= "air" then
+				if node ~= "ignore" then
+					break
+				else
+					-- Err, place at player's pos...
+					pos = minetest.get_player_by_name(player_name):getpos()
+					y_up = -1 -- Will get back to 0
+				end
+				y_up = y_up + 1
+			else
+				break
+			end
 		end
 		minetest.add_node({x=pos.x,y=pos.y+y_up,z=pos.z}, {name='default:water_source'})
 		return true


### PR DESCRIPTION
If a player completes the feat `dig_stone_with_iron` away from their island, the area being unloaded, the loop searching for a free node over the "?" node will loop endelessly and cause a deadlock. The new method puts the water source at the player's position if it detects that the island is in an unloaded chunck.
(See the commits https://github.com/MinetestForFun/server-minetestforfun-skyblock/commit/14d450566b4c10614eb8c8eead1f6f35492c9df3 https://github.com/MinetestForFun/server-minetestforfun-skyblock/commit/c6abebf1b68b83292b56d10f22dd62634d77f289 from which I took the implementation)