### PR TITLE
Update ladders' feats in level 2 with latest names

### DIFF
--- a/skyblock_levels/skyblock.levels.2.lua
+++ b/skyblock_levels/skyblock.levels.2.lua
@@ -45,11 +45,11 @@ skyblock.levels[level].feats = {
 	},
 	{
 		name = 'place 10 Ladders',
-		hint = 'default:ladder',
+		hint = 'default:ladder_wood',
 		feat = 'place_ladder', 
 		count = 10, 
 		reward = 'default:desert_cobble 50',
-		placenode = {'default:ladder'},
+		placenode = {'default:ladder_wood', 'default:ladder_steel'},
 	},
 	{
 		name = 'place 20 Wood Fences',


### PR DESCRIPTION
Minetest Game changed the name of the default ladder, and added another one. I update the code for the quest in level 2 to work and fix #71.