### PR TITLE
Add level 4 (and clean some .env: calls and white spaces)

### DIFF
--- a/skyblock_levels/init.lua
+++ b/skyblock_levels/init.lua
@@ -18,6 +18,7 @@ dofile(modpath..'/skyblock.levels.1.lua')
 dofile(modpath..'/skyblock.levels.2.lua')
 dofile(modpath..'/skyblock.levels.3.lua')
 dofile(modpath..'/skyblock.levels.4.lua')
+dofile(modpath..'/skyblock.levels.5.lua')
 
 dofile(modpath..'/register_abm.lua')
 dofile(modpath..'/register_craft.lua')

--- a/skyblock_levels/register_misc.lua
+++ b/skyblock_levels/register_misc.lua
@@ -38,9 +38,9 @@ minetest.register_on_dieplayer(function(player)
 	else
 		skyblock.feats.reset_level(player_name)
 	end
-	
+
 	-- back to start of this level
-	
+
 end)
 
 -- player receive fields
@@ -59,6 +59,6 @@ if minetest.get_modpath('unified_inventory') then
 		tooltip = 'Skyblock Quests',
 		action = function(player)
 			skyblock.feats.update(player:get_player_name())
-		end,	
+		end,
 	})
 end

--- a/skyblock_levels/register_node.lua
+++ b/skyblock_levels/register_node.lua
@@ -72,7 +72,7 @@ minetest.override_item('default:sapling', {
 		-- check if we have space to make a tree
 		for dy=1,4 do
 			pos.y = pos.y+dy
-			if minetest.env:get_node(pos).name ~= 'air' and minetest.env:get_node(pos).name ~= 'default:leaves' then
+			if minetest.get_node(pos).name ~= 'air' and minetest.get_node(pos).name ~= 'default:leaves' then
 				return
 			end
 			pos.y = pos.y-dy

--- a/skyblock_levels/skyblock.levels.1.lua
+++ b/skyblock_levels/skyblock.levels.1.lua
@@ -93,11 +93,11 @@ skyblock.levels[level].feats = {
 	},
 	{
 		name = 'craft and place a Sign',
-		hint = 'default:sign_wall',
+		hint = 'default:sign_wall_wood',
 		feat = 'place_sign',
 		count = 1,
 		reward = 'default:pick_steel',
-		placenode = {'default:sign_wall'},
+		placenode = {'default:sign_wall_wood'},
 	},
 	{
 		name = 'craft and place a Door',

--- a/skyblock_levels/skyblock.levels.3.lua
+++ b/skyblock_levels/skyblock.levels.3.lua
@@ -162,7 +162,7 @@ skyblock.levels[level].reward_feat = function(player_name, feat)
 	-- add water after dig_stone_with_mese
 	if rewarded and feat == 'dig_stone_with_mese' then
 		local pos = skyblock.get_spawn(player_name)
-		minetest.env:add_node({x=pos.x,y=pos.y+1,z=pos.z}, {name='default:water_source'})
+		minetest.add_node({x=pos.x,y=pos.y+1,z=pos.z}, {name='default:water_source'})
 		return true
 	end
 
@@ -200,10 +200,10 @@ skyblock.levels[level].bucket_water_on_use = function(player_name, pointed_thing
 	
 	-- place_water_infinite
 	local pos = pointed_thing.under
-	if minetest.env:get_node({x=pos.x-1,y=pos.y,z=pos.z-1}).name=='default:water_source' 
-	or minetest.env:get_node({x=pos.x-1,y=pos.y,z=pos.z+1}).name=='default:water_source'
-	or minetest.env:get_node({x=pos.x+1,y=pos.y,z=pos.z-1}).name=='default:water_source'
-	or minetest.env:get_node({x=pos.x+1,y=pos.y,z=pos.z+1}).name=='default:water_source' then
+	if minetest.get_node({x=pos.x-1,y=pos.y,z=pos.z-1}).name=='default:water_source' 
+	or minetest.get_node({x=pos.x-1,y=pos.y,z=pos.z+1}).name=='default:water_source'
+	or minetest.get_node({x=pos.x+1,y=pos.y,z=pos.z-1}).name=='default:water_source'
+	or minetest.get_node({x=pos.x+1,y=pos.y,z=pos.z+1}).name=='default:water_source' then
 		skyblock.feats.add(level,player_name,'place_water_infinite')
 		return
 	end

--- a/skyblock_levels/skyblock.levels.4.lua
+++ b/skyblock_levels/skyblock.levels.4.lua
@@ -8,6 +8,23 @@ License: GPLv3
 
 ]]--
 
+--[[
+Level 4 mostly revolving around farming and dying
+level 4 feats and rewards:
+
+* craft_diamondhoe       farming:seed_wheat
+* use_hoe x40            farming:melon_slice
+* plant_wheatseed        default:cactus
+* craft_flour            farming:seed_cotton x10
+* place_snowblock x50    dye:red x20
+* dig_cactus x10         dye:white x20
+* dig_geranium x5        flowers:mushroom_brown x2
+* dig_tulip x5           flowers:mushroom_red x2
+* dig_brownmushroom x15  farming:corn x50
+* craft_ethanol          default:meselamp x5
+
+]]--
+
 local level = 4
 
 --
@@ -17,22 +34,99 @@ local level = 4
 skyblock.levels[level] = {}
 
 -- feats
-skyblock.levels[level].feats = {}
+-- Parts of this are purely hypothetical and not implement yet
+skyblock.levels[level].feats = {
+   {
+      name = "Craft a mese hoe",
+      hint = "farming:hoe_mese",
+      feat = "craft_mesehoe",
+      count = 1,
+      reward = "farming:seed_wheat 2",
+      craft = {"farming:hoe_mese"}
+   },
+   {
+      name = "Use the hoe 40 times",
+      hint = "farming:hoe_mese",
+      feat = "use_hoe",
+      count = 40,
+      reward = "farming:melon_slice",
+      hoeuse = {}
+   },
+   {
+      name = "Plant 10 wheat seeds",
+      hint = "farming:seed_wheat",
+      feat = "place_wheatseed",
+      count = 10,
+      reward = "default:cactus",
+      placenode = {"farming:seed_wheat"}
+   },
+   {
+      name = "Craft 4 lumps of flour",
+      hint = "farming:flour",
+      feat = "craft_flour",
+      count = 4,
+      reward = "farming:seed_cotton 10",
+      craft = {"farming:flour"},
+   },
+   {
+      name = "Place 50 snow blocks",
+      hint = "default:snowblock",
+      feat = "place_snowblock",
+      count = 50,
+      reward = "dye:red 20",
+      placenode = {"default:snowblock"},
+   },
+   {
+      name = "Dig 10 cacti",
+      hint = "default:cactus",
+      feat = "dig_cactus",
+      count = 10,
+      reward = "dye:white 20",
+      dignode = {"default:cactus"},
+   },
+   {
+      name = "Pick 5 Geranium flowers",
+      hint = "flowers:geranium",
+      feat = "dig_geranium",
+      count = 5,
+      reward = "flowers:mushroom_brown 2",
+      dignode = {"flowers:geranium"},
+   },
+   {
+      name = "Pick 5 orange tulips",
+      hint = "flowers:tulip",
+      feat = "dig_tulip",
+      count = 5,
+      reward = "flowers:mushroom_red 2",
+      dignode = {"flowers:tulip"},
+   },
+   {
+      name = "Dig 10 brown mushrooms",
+      hint = "flowers:mushroom_brown",
+      feat = "dig_brownmushroom",
+      count = 10,
+      reward = "farming:corn",
+      dignode = {"flowers:mushroom_brown"},
+   },
+   {
+      name = "Make ethanol!",
+      hint = "farming:corn",
+      feat = "craft_ethanol",
+      count = 1,
+      reward = "default:meselamp 5",
+      craft = {"farming:bottle_ethanol"},
+   }
+}
 
 -- init level
 skyblock.levels[level].init = function(player_name)
-	local privs = core.get_player_privs(player_name)
-	privs['fly'] = true
-	privs['fast'] = true
-	core.set_player_privs(player_name, privs)
-	minetest.chat_send_player(player_name, 'You can now use FLY and FAST !')
 end
 
 -- get level information
 skyblock.levels[level].get_info = function(player_name)
 	local info = { 
 		level=level, 
-		total=1, 
+		total=10, 
 		count=0, 
 		player_name=player_name, 
 		infotext='', 
@@ -40,23 +134,58 @@ skyblock.levels[level].get_info = function(player_name)
 		formspec_quest = '',
 	}
 	
-	local text = 'label[0,0.5; THE END]'
-		..'label[0,1.0; I hope you enjoyed your journey, and you]'
-		..'label[0,1.5; are welcome to stay and keep building]'
-		..'label[0,2.0; your new sky world.]'
-		
+	local text = 'label[0,2.7; --== Quests ==--]'
+		..'label[0,0.5; Time Goes On, '..player_name..'...]'
+		..'label[0,1.0; You may wonder, traveller, where some of your]'
+		..'label[0,1.5; precious items are. Be patient...]'
+		..'label[0,2.0; They will come to you in time...]'
+
 	info.formspec = skyblock.levels.get_inventory_formspec(level,info.player_name,true)..text
 	info.formspec_quest = skyblock.levels.get_inventory_formspec(level,info.player_name)..text
-	info.infotext = 'THE END! for '.. player_name ..' ... or is it ...'
+
+	for k,v in ipairs(skyblock.levels[level].feats) do
+		info.formspec = info.formspec..skyblock.levels.get_feat_formspec(info,k,v.feat,v.count,v.name,v.hint,true)
+		info.formspec_quest = info.formspec_quest..skyblock.levels.get_feat_formspec(info,k,v.feat,v.count,v.name,v.hint)
+	end
+	if info.count>0 then
+		info.count = info.count/2 -- only count once
+	end
+
+	info.infotext = 'LEVEL '..info.level..' for '..info.player_name..': '..info.count..' of '..info.total
+	
 	return info
 end
 
--- no feat tracking
-skyblock.levels[level].reward_feat = function(player_name, feat) end
-skyblock.levels[level].on_placenode = function(pos, newnode, placer, oldnode) end
-skyblock.levels[level].on_dignode = function(pos, oldnode, digger) end
-skyblock.levels[level].on_item_eat = function(player_name, itemstack) end
-skyblock.levels[level].on_craft = function(player_name, itemstack) end
+-- Reward feats
+skyblock.levels[level].reward_feat = function(player_name, feat)
+   return skyblock.levels.reward_feat(level, player_name, feat)
+end
+
+-- Track node placement
+skyblock.levels[level].on_placenode = function(pos, newnode, placer, oldnode)
+   skyblock.levels.on_placenode(level, pos, newnode, placer, oldnode)
+end
+
+-- Track node digging
+skyblock.levels[level].on_dignode = function(pos, oldnode, digger)
+   skyblock.levels.on_dignode(level, pos, oldnode, digger)
+end
+
+-- track eating feats
+skyblock.levels[level].on_item_eat = function(player_name, itemstack)
+   skyblock.levels.on_item_eat(level, player_name, itemstack)
+end
+
+-- track crafting feats
+skyblock.levels[level].on_craft = function(player_name, itemstack)
+   skyblock.levels.on_craft(level, player_name, itemstack)
+end
+
+-- track hoe use
+skyblock.levels[level].hoe_on_use = function(player_name, pointed_thing, wieldeditem)
+   skyblock.levels.hoe_on_use(level, player_name, pointed_thing, wieldeditem)
+end
+
 skyblock.levels[level].bucket_on_use = function(player_name, pointed_thing) end
 skyblock.levels[level].bucket_water_on_use = function(player_name, pointed_thing) end
 skyblock.levels[level].bucket_lava_on_use = function(player_name, pointed_thing) end

--- a/skyblock_levels/skyblock.levels.5.lua
+++ b/skyblock_levels/skyblock.levels.5.lua
@@ -1,0 +1,62 @@
+--[[
+
+Skyblock for Minetest
+
+Copyright (c) 2015 cornernote, Brett O'Donnell <cornernote@gmail.com>
+Source Code: https://github.com/cornernote/minetest-skyblock
+License: GPLv3
+
+]]--
+
+local level = 5
+
+--
+-- PUBLIC FUNCTIONS
+--
+
+skyblock.levels[level] = {}
+
+-- feats
+skyblock.levels[level].feats = {}
+
+-- init level
+skyblock.levels[level].init = function(player_name)
+	local privs = core.get_player_privs(player_name)
+	privs['fly'] = true
+	privs['fast'] = true
+	core.set_player_privs(player_name, privs)
+	minetest.chat_send_player(player_name, 'You can now use FLY and FAST !')
+end
+
+-- get level information
+skyblock.levels[level].get_info = function(player_name)
+	local info = { 
+		level=level, 
+		total=1, 
+		count=0, 
+		player_name=player_name, 
+		infotext='', 
+		formspec = '', 
+		formspec_quest = '',
+	}
+	
+	local text = 'label[0,0.5; THE END]'
+		..'label[0,1.0; I hope you enjoyed your journey, and you]'
+		..'label[0,1.5; are welcome to stay and keep building]'
+		..'label[0,2.0; your new sky world.]'
+		
+	info.formspec = skyblock.levels.get_inventory_formspec(level,info.player_name,true)..text
+	info.formspec_quest = skyblock.levels.get_inventory_formspec(level,info.player_name)..text
+	info.infotext = 'THE END! for '.. player_name ..' ... or is it ...'
+	return info
+end
+
+-- no feat tracking
+skyblock.levels[level].reward_feat = function(player_name, feat) end
+skyblock.levels[level].on_placenode = function(pos, newnode, placer, oldnode) end
+skyblock.levels[level].on_dignode = function(pos, oldnode, digger) end
+skyblock.levels[level].on_item_eat = function(player_name, itemstack) end
+skyblock.levels[level].on_craft = function(player_name, itemstack) end
+skyblock.levels[level].bucket_on_use = function(player_name, pointed_thing) end
+skyblock.levels[level].bucket_water_on_use = function(player_name, pointed_thing) end
+skyblock.levels[level].bucket_lava_on_use = function(player_name, pointed_thing) end

--- a/skyblock_levels/skyblock.levels.lua
+++ b/skyblock_levels/skyblock.levels.lua
@@ -241,7 +241,7 @@ end
 
 -- track bucket feats
 function skyblock.levels.bucket_on_use(level,player_name,pointed_thing)
-	local node = minetest.env:get_node(pointed_thing.under)
+	local node = minetest.get_node(pointed_thing.under)
 	for _,v in ipairs(skyblock.levels[level].feats) do
 		if v.bucket then
 			for _,vv in ipairs(v.bucket) do
@@ -255,8 +255,8 @@ function skyblock.levels.bucket_on_use(level,player_name,pointed_thing)
 end
 
 -- track bucket water feats
-function skyblock.levels.bucket_water_on_use(level,player_name,pointed_thing) 
-	local node = minetest.env:get_node(pointed_thing.under)
+function skyblock.levels.bucket_water_on_use(level,player_name,pointed_thing)
+	local node = minetest.get_node(pointed_thing.under)
 	for _,v in ipairs(skyblock.levels[level].feats) do
 		if v.bucket_water then
 			for _,vv in ipairs(v.bucket_water) do
@@ -271,7 +271,7 @@ end
 
 -- track bucket lava feats
 function skyblock.levels.bucket_lava_on_use(level,player_name,pointed_thing)
-	local node = minetest.env:get_node(pointed_thing.under)
+	local node = minetest.get_node(pointed_thing.under)
 	for _,v in ipairs(skyblock.levels[level].feats) do
 		if v.bucket_lava then
 			for _,vv in ipairs(v.bucket_lava) do
@@ -282,4 +282,22 @@ function skyblock.levels.bucket_lava_on_use(level,player_name,pointed_thing)
 			end
 		end
 	end
+end
+
+-- track hoe usage
+function skyblock.levels.hoe_on_use(level, player_name, pointed_thing, itemname)
+   for _, v in pairs(skyblock.levels[level].feats) do
+      if v.hoeuse then
+	 for _, vv in pairs(v.hoeuse) do
+	    if itemname == "farming:hoe_" .. vv then
+	       skyblock.feats.add(level, player_name, v.feat)
+	       return
+	    end
+	 end
+	 if #v.hoeuse == 0 then
+	    skyblock.feats.add(level, player_name, v.feat)
+	    return
+	 end
+      end
+   end
 end


### PR DESCRIPTION
Two major issues come to my mind though : 
- The last quest (craft_ethanol) requires [TenPlus1's farming_redo](https://github.com/TenPlus1/farming) and will not work with vanilla's farming
- There is no code (I think) removing fly and fast to people already on level 4. All players could be equal by still granting them on level 4, but we kept it as a reward for finishing the game.
